### PR TITLE
Converting socket connections from UDP -> TCP to improve stability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@callstack/repack": "blitzstudios/repack.git#callstack-repack-v2.5.3-gitpkg",
+    "@callstack/repack": "blitzstudios/repack.git#callstack-repack-v2.6.0-gitpkg",
     "@react-native-community/netinfo": "^9.3.7",
     "axios": "0.15.3",
     "lodash": "4.17.21",
@@ -41,7 +41,7 @@
     "react-native": "0.66.5",
     "react-native-linear-gradient": "2.5.6",
     "react-native-svg": "13.7.0",
-    "react-native-udp": "^4.1.6"
+    "react-native-tcp-socket": "^6.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
### Description

This commit is part of a 4-part (4 repos) PR to change the socket event protocol from UDP to TCP for minis.

This allows us to maintain stateful connections, receive packets in order, and transmit much more data over the network during mini development.

See all PRs here:
[sleeper-mini](https://github.com/blitzstudios/sleeper-mini/pull/5)
[sleeper-mini-core](https://github.com/blitzstudios/sleeper-mini-core/pull/6)
[sleeperbot](https://github.com/blitzstudios/sleeperbot/pull/5433)
[repack](https://github.com/blitzstudios/repack/commit/f0b4a04cbb98394e2cd9b7ca1e61faf96a4bb3e0)

### How To Test

1. Load each branch locally.
2. Start the template project and Sleeper app in either order.
3. Make sure a connection is established.
4. Context sends and source code changes should all refresh as expected.
