### PR TITLE
Adding User and Matchup lookups

### DIFF
--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,4 +1,4 @@
-import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap } from './types';
+import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap } from './types';
 import SleeperActions from './sleeper_actions';
 declare class SleeperContext {
     user: User;
@@ -8,6 +8,7 @@ declare class SleeperContext {
     userLeagueList: string[];
     rostersInLeagueMap: RostersInLeagueMap;
     userMap: UserMap;
+    matchupsInLeagueMap: MatchupsInLeagueMap;
     actions: SleeperActions;
     constructor();
 }

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,4 +1,4 @@
-import { User, Navigation, League, LeaguesMap, RostersInLeagueMap } from './types';
+import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap } from './types';
 import SleeperActions from './sleeper_actions';
 type SleeperContextConfig = {
     user: User;
@@ -7,6 +7,7 @@ type SleeperContextConfig = {
     userLeagueList: string[];
     leaguesMap: LeaguesMap;
     rostersInLeagueMap: RostersInLeagueMap;
+    userMap: UserMap;
 };
 declare class SleeperContext {
     user: User;
@@ -15,6 +16,7 @@ declare class SleeperContext {
     leaguesMap: LeaguesMap;
     userLeagueList: string[];
     rostersInLeagueMap: RostersInLeagueMap;
+    userMap: UserMap;
     actions: SleeperActions;
     constructor(config: SleeperContextConfig);
 }

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,14 +1,5 @@
 import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap } from './types';
 import SleeperActions from './sleeper_actions';
-type SleeperContextConfig = {
-    user: User;
-    navigation: Navigation;
-    league: League;
-    userLeagueList: string[];
-    leaguesMap: LeaguesMap;
-    rostersInLeagueMap: RostersInLeagueMap;
-    userMap: UserMap;
-};
 declare class SleeperContext {
     user: User;
     navigation: Navigation;
@@ -18,6 +9,6 @@ declare class SleeperContext {
     rostersInLeagueMap: RostersInLeagueMap;
     userMap: UserMap;
     actions: SleeperActions;
-    constructor(config: SleeperContextConfig);
+    constructor();
 }
 export default SleeperContext;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -1,8 +1,8 @@
 import { NAVIGATION_ID, NAVIGATION_TYPE } from './redux/native_nav/constants.d';
-import { League, Roster } from './shared/graphql.d';
-export * from './shared/graphql.d';
+import { League, Roster, User } from './shared/graphql.d';
 export type NavigationType = typeof NAVIGATION_TYPE[keyof typeof NAVIGATION_TYPE];
 export type NavigationTypeId = typeof NAVIGATION_ID[keyof typeof NAVIGATION_ID];
+export * from './shared/graphql.d';
 export type Navigation = {
     selectedNavType: NavigationType;
     selectedNavTypeId: NavigationTypeId;
@@ -10,6 +10,8 @@ export type Navigation = {
 };
 export type LeagueId = string;
 export type RosterId = string;
+export type UserId = string;
 export type LeaguesMap = Record<LeagueId, League>;
 export type RostersMap = Record<RosterId, Roster>;
 export type RostersInLeagueMap = Record<LeagueId, RostersMap>;
+export type UserMap = Record<UserId, User>;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -1,5 +1,5 @@
 import { NAVIGATION_ID, NAVIGATION_TYPE } from './redux/native_nav/constants.d';
-import { League, Roster, User } from './shared/graphql.d';
+import { League, Roster, User, MatchupLeg } from './shared/graphql.d';
 export type NavigationType = typeof NAVIGATION_TYPE[keyof typeof NAVIGATION_TYPE];
 export type NavigationTypeId = typeof NAVIGATION_ID[keyof typeof NAVIGATION_ID];
 export * from './shared/graphql.d';
@@ -11,7 +11,10 @@ export type Navigation = {
 export type LeagueId = string;
 export type RosterId = string;
 export type UserId = string;
+export type MatchupWeek = number;
 export type LeaguesMap = Record<LeagueId, League>;
 export type RostersMap = Record<RosterId, Roster>;
 export type RostersInLeagueMap = Record<LeagueId, RostersMap>;
 export type UserMap = Record<UserId, User>;
+export type MathchupWeekMap = Record<MatchupWeek, MatchupLeg>;
+export type MatchupsInLeagueMap = Record<LeagueId, MathchupWeekMap>;

--- a/declarations/types/shared/graphql.d.ts
+++ b/declarations/types/shared/graphql.d.ts
@@ -71,6 +71,24 @@ export type League = {
     status?: Maybe<Scalars['String']>;
     total_rosters?: Maybe<Scalars['Int']>;
 };
+export type MatchupLeg = {
+    __typename?: 'MatchupLeg';
+    bans?: Maybe<Scalars['Map']>;
+    custom_points?: Maybe<Scalars['Float']>;
+    league_id?: Maybe<Scalars['Snowflake']>;
+    leg?: Maybe<Scalars['Int']>;
+    matchup_id?: Maybe<Scalars['Int']>;
+    max_points?: Maybe<Scalars['Float']>;
+    picks?: Maybe<Scalars['Map']>;
+    player_map?: Maybe<Scalars['Map']>;
+    players?: Maybe<Scalars['Set']>;
+    points?: Maybe<Scalars['Float']>;
+    proj_points?: Maybe<Scalars['Float']>;
+    roster_id?: Maybe<Scalars['Int']>;
+    round?: Maybe<Scalars['Int']>;
+    starters?: Maybe<Scalars['List']>;
+    starters_games?: Maybe<Scalars['Map']>;
+};
 export type Roster = {
     __typename?: 'Roster';
     co_owners?: Maybe<Scalars['SnowflakeSet']>;

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -44,7 +44,7 @@ const DevServer = props => {
     const message: SocketMessage = {_contextGet: propertyPath};
     const json = JSON.stringify(message);
     try {
-      socket?.write(json);
+      socket?.write(json + '\n');
     } catch (e) {
       console.log("[Sleeper] Failed to send context request: ", e);
     }
@@ -111,7 +111,7 @@ const DevServer = props => {
       const message: SocketMessage = { _ip: ipAddress };
       const json = JSON.stringify(message);
       try {
-        connection.current?.write(json, undefined, (error) => {
+        connection.current?.write(json + '\n', "utf8", (error) => {
           if (error) {
             return stopSocket();
           }

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -21,7 +21,7 @@ const DevServer = props => {
   const onSocket = (handler) => msg => {
     let json;
     try {
-      json = JSON.parse(msg);
+      json = JSON.parse(msg); 
     } catch(e) {
       partialMessage.current += msg;
     }
@@ -53,40 +53,53 @@ const DevServer = props => {
   const proxyHandler = (socket) => {
     return {
       get: (target, property) => {
-        if (property in target && target[property] !== null) {
-          const value = target[property];
+        let value = Reflect.get(target, property);
 
-          if (typeof value !== 'object' || value._isProxy) {
-            return value;
-          }
-
+        // Check if we need to add a proxy to this object
+        if (!!value && typeof value === 'object' && !value._isProxy && value._isProxyInternal) {
+          const isLeaf = !value._continueProxy;
           // Adding proxies to objects
-          // Intentionally only going 1 level deep
-          const handler = proxyHandlerLeaf(socket, property);
-          target[property] = new Proxy(value, handler);
-          target[property]._isProxy = true;
-
-          return target[property];
+          const handler = proxyHandlerChild(socket, property, isLeaf);
+          const proxiedValue = new Proxy(value, handler);
+          Reflect.set(target, property, proxiedValue);
+          value = proxiedValue;
         }
 
-        // This property is not in the context object yet
-        sendContextRequest(socket, property);
-        return null;
+        return value;
       }
     };
   }
 
-  // This handler is for leaf nodes only
-  const proxyHandlerLeaf = (socket, path) => {
+  const proxyHandlerChild = (socket, path, isLeaf) => {
     return {
       get: (target, property) => {
-        if (target[property] !== undefined) { // Only checking undefined properites for leaves
-          return target[property];
+        // Check if a proxy was already added to this object
+        if (property === '_isProxy') {
+          return true;
         }
 
-        const fullProp = path + '.' + property;
-        sendContextRequest(socket, fullProp);
-        return null;
+        const value = Reflect.get(target, property);
+        const fullPropertyPath = `${path}.${property}`;
+
+        // If the value is undefined, we need to request it from the server
+        if (value === undefined && isLeaf) {
+          sendContextRequest(socket, fullPropertyPath);
+        }
+
+        // Check if we need to add a second layer proxy to this object
+        if (!isLeaf && !value?._isProxy) {
+          const nextLeaf = true; // Currently we only support 2 layers of proxies
+          // Adding proxies to objects
+          // These proxies aren't stored in the context object so we will regenerate them every time
+          const handler = proxyHandlerChild(socket, fullPropertyPath, nextLeaf);
+          if (value === undefined) {
+            return new Proxy({}, handler);
+          } else {
+            return new Proxy(value, handler);
+          }
+        }
+
+        return value;
       }
     };
   }


### PR DESCRIPTION
### Description
- Adding `userMap`, accessed by `context.userMap.(userId)`
- Adding `matchupsInLeagueMap` accessed by `matchupsInLeagueMap.(leagueId).(week#)` -- both arguments are required.

Some changes to the data passed through TCP, so this needs to be updated with the Sleeper Client.