### PR TITLE
Adding new navigation typescript declarations.

### DIFF
--- a/declarations/sleeper_actions.d.ts
+++ b/declarations/sleeper_actions.d.ts
@@ -1,4 +1,4 @@
 import { NavigationTabId } from './types';
 export type SleeperActions = {
-    navigate: (navTabType: NavigationTabId, args: any) => void;
+  navigate: (navTabType: NavigationTabId, args?: any) => void;
 };

--- a/declarations/sleeper_actions.d.ts
+++ b/declarations/sleeper_actions.d.ts
@@ -1,5 +1,8 @@
-import { NavigationType, NavigationTypeId } from './types';
-declare class SleeperActions {
-    navigate: (navType: NavigationType, navTypeId: NavigationTypeId) => void;
-}
-export default SleeperActions;
+import { NavigationType, NavigationTypeId, NavigationTabId } from './types';
+export type SleeperActions = {
+    /**
+     * @deprecated Use navigateTab instead.
+     */
+    navigate?: (navType: NavigationType, navTypeId: NavigationTypeId) => void;
+    navigateTab: (navTabType: NavigationTabId, args: any) => void;
+};

--- a/declarations/sleeper_actions.d.ts
+++ b/declarations/sleeper_actions.d.ts
@@ -1,8 +1,4 @@
-import { NavigationType, NavigationTypeId, NavigationTabId } from './types';
+import { NavigationTabId } from './types';
 export type SleeperActions = {
-    /**
-     * @deprecated Use navigateTab instead.
-     */
-    navigate?: (navType: NavigationType, navTypeId: NavigationTypeId) => void;
-    navigateTab: (navTabType: NavigationTabId, args: any) => void;
+    navigate: (navTabType: NavigationTabId, args: any) => void;
 };

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,10 +1,9 @@
-import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap } from './types';
+import { User, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap } from './types';
 import type { SleeperActions } from './sleeper_actions';
 
 declare class SleeperContext {
     static apiLevel: string;
     user: User;
-    navigation: Navigation;
     league: League;
     leaguesMap: LeaguesMap;
     userLeagueList: string[];

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,5 +1,6 @@
 import { User, Navigation, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap } from './types';
-import SleeperActions from './sleeper_actions';
+import type { SleeperActions } from './sleeper_actions';
+
 declare class SleeperContext {
     static apiLevel: string;
     user: User;
@@ -20,6 +21,5 @@ declare class SleeperContext {
     draftPicksInDraftMap: DraftPicksInDraftMap;
     playersInSportMap: PlayersInSportMap;
     actions: SleeperActions;
-    constructor();
 }
 export default SleeperContext;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -1,14 +1,6 @@
-import { NAVIGATION_ID, NAVIGATION_TYPE, NAVIGATION_TAB_ID } from './redux/native_nav/constants.d';
 import { League, Roster, User, MatchupLeg, LeagueTransaction, Draft, DraftPick, RosterDraftPick, Player } from './shared/graphql.d';
-export type NavigationType = typeof NAVIGATION_TYPE[keyof typeof NAVIGATION_TYPE];
-export type NavigationTypeId = typeof NAVIGATION_ID[keyof typeof NAVIGATION_ID];
-export type NavigationTabId = 'LeaguesDetailScreen' | 'PicksIndexScreen';
+export type NavigationTabId = 'LeaguesIndexScreen' | 'LeaguesDetailScreen' | 'ScoreIndexScreen' | 'ScoreDetailScreen' | 'PicksIndexScreen' | 'FeedIndexScreen' | 'WebviewScreen' | 'ManageChannelsScreen' | 'InboxIndexScreen' | 'MinisIndexScreen' | 'ManageChannelsScreen' | 'InboxIndexScreen' | 'MinisIndexScreen';
 export * from './shared/graphql.d';
-export type Navigation = {
-    selectedNavType: NavigationType;
-    selectedNavTypeId: NavigationTypeId;
-    selectedNavData: {};
-};
 export type LeagueId = string;
 export type RosterId = string;
 export type UserId = string;
@@ -57,7 +49,7 @@ export type MatchupsInLeagueMap = Record<LeagueId, MathchupWeekMap>;
 export type UsersInLeagueMap = Record<LeagueId, UserMap>;
 export type PlayoffsInLeagueMap = Record<LeagueId, BracketSet>;
 export type TransactionsInLeagueMap = Record<LeagueId, TransactionId[]>;
-export type TransactionsMap = Record    <TransactionId, LeagueTransaction>;
+export type TransactionsMap = Record<TransactionId, LeagueTransaction>;
 export type SportInfoMap = Record<SportType, SportInfo>;
 export type DraftsInLeagueMap = Record<LeagueId, Draft[]>;
 export type DraftPickTradesInLeagueMap = Record<LeagueId, RosterDraftPick[]>;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -1,7 +1,8 @@
-import { NAVIGATION_ID, NAVIGATION_TYPE } from './redux/native_nav/constants.d';
+import { NAVIGATION_ID, NAVIGATION_TYPE, NAVIGATION_TAB_ID } from './redux/native_nav/constants.d';
 import { League, Roster, User, MatchupLeg, LeagueTransaction, Draft, DraftPick, RosterDraftPick, Player } from './shared/graphql.d';
 export type NavigationType = typeof NAVIGATION_TYPE[keyof typeof NAVIGATION_TYPE];
 export type NavigationTypeId = typeof NAVIGATION_ID[keyof typeof NAVIGATION_ID];
+export type NavigationTabId = 'LeaguesDetailScreen' | 'PicksIndexScreen';
 export * from './shared/graphql.d';
 export type Navigation = {
     selectedNavType: NavigationType;
@@ -34,18 +35,18 @@ export type Bracket = {
 export type BracketSet = {
     bracket: Bracket[];
     loserBracket: Bracket[];
-}
+};
 export type SportInfo = {
     season_type: string;
     season: string;
-    week: number;
-    display_week: number;
-    leg: number;
-    league_season: string;
-    league_create_season: string;
-    previous_season: string;
-    season_start_date: string;
-    season_end_date: string;
+    week?: number;
+    display_week?: number;
+    leg?: number;
+    league_season?: string;
+    league_create_season?: string;
+    previous_season?: string;
+    season_start_date?: string;
+    season_end_date?: string;
 };
 export type LeaguesMap = Record<LeagueId, League>;
 export type RostersMap = Record<RosterId, Roster>;
@@ -53,13 +54,27 @@ export type RostersInLeagueMap = Record<LeagueId, RostersMap>;
 export type UserMap = Record<UserId, User>;
 export type MathchupWeekMap = Record<MatchupWeek, MatchupLeg>;
 export type MatchupsInLeagueMap = Record<LeagueId, MathchupWeekMap>;
-export type UsersInLeagueMap = Record<LeagueId, Record<UserId, User>>;
+export type UsersInLeagueMap = Record<LeagueId, UserMap>;
 export type PlayoffsInLeagueMap = Record<LeagueId, BracketSet>;
 export type TransactionsInLeagueMap = Record<LeagueId, TransactionId[]>;
-export type TransactionsMap = Record<TransactionId, LeagueTransaction>;
+export type TransactionsMap = Record    <TransactionId, LeagueTransaction>;
 export type SportInfoMap = Record<SportType, SportInfo>;
 export type DraftsInLeagueMap = Record<LeagueId, Draft[]>;
 export type DraftPickTradesInLeagueMap = Record<LeagueId, RosterDraftPick[]>;
 export type DraftPicksInDraftMap = Record<DraftId, DraftPick[]>;
 export type PlayersMap = Record<PlayerId, Player>;
 export type PlayersInSportMap = Record<SportType, PlayersMap>;
+export declare enum MiniCategory {
+    DEVELOPER = "Developer",
+    FEATURED = "Featured",
+    GAMES = "Games",
+    SPORTUTILITY = "Sport Utility"
+}
+export type Mini = {
+    name: string;
+    description: string;
+    image: string;
+    category: MiniCategory;
+    id: string;
+};
+export type VersionMap = Record<string, Mini>;

--- a/declarations/types/redux/native_nav/constants.d.ts
+++ b/declarations/types/redux/native_nav/constants.d.ts
@@ -21,3 +21,11 @@ export declare const NAVIGATION_ID: {
     readonly MENTIONS: 6;
     readonly FRIENDS: 7;
 };
+export declare const NAVIGATION_TAB_ID: {
+    readonly FantasyTab: "FantasyTab";
+    readonly ScoresTab: "ScoresTab";
+    readonly GamesTab: "GamesTab";
+    readonly FeedTab: "FeedTab";
+    readonly InboxTab: "InboxTab";
+    readonly MinisTab: "MinisTab";
+};


### PR DESCRIPTION
### Description

This commit updates navigation to the new 6-tab standard. As such, the old navigation context property has been removed and new navigation actions have been added.

To avoid some messy code checks, the deprecated properties have been removed completely rather than kept as no-ops. While this means the typescript itself is non backwards compatible, there isn't really anything in here that will break runtime logic for existing minis.