### PR TITLE
Fixing issue loading built-in sleeper components in dev mode if a prod version map has not yet been uploaded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -251,7 +251,7 @@ const DevServer = props => {
         let isInitialized = !!_dataRef.current?.dist;
 
         // Non-staging builds also require a version map to be defined.
-        if (!_dataRef.current?.isStaging) {
+        if (!_dataRef.current?.isStaging && !config.dev) {
           isInitialized = !!_versionMap.current;
         }
 


### PR DESCRIPTION
### Description

When developing minis internally and connecting to a local dev-mode version of sleeper, the mini dev server was attempting to load version map files from the CDN that it didn't need, hanging any load operation. This commit fixes that by bypassing the version map load in dev.

### How To Test

1. Load up sleeper locally on a simulator, connect to the sleeper-mini template project.
2. Set app.json to include `dev: true`.
3. Ensure that bundle loads work on the latest version before running any submission scripts.