### PR TITLE
Removing eager from all module federation shared dependencies. Updating repack to fix bug preventing this.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@callstack/repack": "blitzstudios/repack.git#callstack-repack-v2.6.3-gitpkg",
+    "@callstack/repack": "blitzstudios/repack.git#callstack-repack-v2.7.0-gitpkg",
     "@callstack/repack-dev-server": "blitzstudios/repack.git#callstack-repack-dev-server-v1.0.7-gitpkg",
     "@react-native-community/cli": "6.4.0",
     "@react-native-community/cli-types": "6.0.0",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {Platform} from 'react-native';
 import {Config, SocketMessage} from '../types';
 import { ScriptLocatorResolver, ScriptManager, Federated } from '@callstack/repack/client';
-import NetInfo from '@react-native-community/netinfo';
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
 import TcpSocket from 'react-native-tcp-socket';
 import { fetchMainVersionMap, getMainUrl } from './url_resolver';
 
@@ -179,8 +179,10 @@ const DevServer = props => {
   }
 
   const startSocket = async () => {
-    const netInfo = await NetInfo.fetch();
+    const netInfo: NetInfoState = await NetInfo.fetch();
+
     const netInfoDetails = netInfo?.details;
+    // @ts-ignore
     const ipAddress = netInfoDetails?.ipAddress;
 
     if (!netInfoDetails || !('ipAddress' in netInfoDetails)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export * from '../../declarations/types/index.d';
 export { default as Context } from '../../declarations/sleeper_context.d';
-export { default as SocketMessage } from '../../declarations/sleeper_message.d';
+export type { default as SocketMessage } from '../../declarations/sleeper_message.d';
 
 export type Config = {
   name: string,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,6 @@ const Repack = require('../../../node_modules/@callstack/repack');
 const config = require('../../../app.json');
 const {dependencies} = require('../../../package.json');
 
-const sharedDeps = Object.keys(dependencies).reduce((acc, key) => {
-  acc[key] = {singleton: true, eager: true, requiredVersion: dependencies[key]};
-  return acc;
-}, {});
-
 const {samples, selectedSample} = config;
 const sampleClassPath = `../../../src/${samples[selectedSample]}`;
 const sampleClassPathLocal = `./src/${samples[selectedSample]}`
@@ -47,6 +42,11 @@ module.exports = env => {
   }
 
   const dev = mode === 'development';
+
+  const sharedDeps = Object.keys(dependencies).reduce((acc, key) => {
+    acc[key] = {singleton: true, eager: dev, requiredVersion: dependencies[key]};
+    return acc;
+  }, {});
 
   /**
    * Using Module Federation might require disabling hmr.


### PR DESCRIPTION
### Description

This commit massively reduces download size of minis by removing `eager` from all shared dependencies. From now on, when webpack generates a mini it will split out all of the packages it uses into separate, external bundles rather than including them within the main container. Since sleeper already includes most of those packages that minis use, we only need to download the much smaller container and any packages that we don't already have, rather than everything.

Note that for devs working locally, `eager` is still required in order to run in standalone mode for the simulator. So we only set `eager` to false when doing submissions.

In order to get this working, there was a minor bugfix required in repack [here](https://github.com/blitzstudios/repack/commit/0c69fca4412a055855e12fc1ff12771b619e6435).
