### PR TITLE
Syncronizing runtime babel packages with main sleeper app to avoid extra runtime package downloads.

### DIFF
--- a/bin/preload_packages.js
+++ b/bin/preload_packages.js
@@ -26,6 +26,11 @@ const main = async () => {
   // Get the dependencies
   const dependencies = packageJson.dependencies;
 
+  // Remove packages that cause conflicts
+  delete dependencies['@babel/runtime'];
+  delete dependencies['@babel/plugin-transform-runtime'];
+  delete dependencies['regenerator-runtime'];
+
   // Write a ./package_list.js file that imports all dependencies
   const packageListPath = path.join('package_list.js');
   const packageList = Object.keys(dependencies).map(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",
@@ -34,6 +34,8 @@
     "access": "public"
   },
   "dependencies": {
+    "@babel/runtime": "7.15.4",
+    "@babel/plugin-transform-runtime": "7.15.0",
     "@callstack/repack": "blitzstudios/repack.git#callstack-repack-v2.7.0-gitpkg",
     "@callstack/repack-dev-server": "blitzstudios/repack.git#callstack-repack-dev-server-v1.0.7-gitpkg",
     "@react-native-community/cli": "6.1.0",
@@ -47,6 +49,7 @@
     "react-native-rename": "^3.2.12",
     "react-refresh": "0.14.0",
     "react-test-renderer": "17.0.2",
+    "regenerator-runtime": "0.13.9",
     "terser-webpack-plugin": "5.3.6",
     "webpack": "5.75.0"
   },
@@ -58,7 +61,6 @@
   "devDependencies": {
     "@babel/core": "7.15.8",
     "@babel/preset-typescript": "7.21.4",
-    "@babel/runtime": "7.15.4",
     "@react-native-community/eslint-config": "^2.0.0",
     "@types/react-native": "0.67.7",
     "@typescript-eslint/eslint-plugin": "^5.31.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -212,8 +212,8 @@ module.exports = env => {
               /** Add React Refresh transform only when HMR is enabled. */
               plugins:
                 devServer && devServer.hmr
-                  ? ['module:react-refresh/babel']
-                  : undefined,
+                  ? ['@babel/plugin-transform-runtime', 'module:react-refresh/babel']
+                  : ['@babel/plugin-transform-runtime'],
               babelrc: false,
               comments: true, // necessary for named chunks
               cacheDirectory: true,


### PR DESCRIPTION
### Description

In doing some profiling for minis, I noticed that loading a mini in the main Sleeper app would trigger downloads of a lot of supplemental third party packages that seemed unnecessary.

Digging into this more, it looks like some of our babel runtime packages end up being required by mini code, but was not exported to module federation in Sleeper.

This commit fixes that by synchronizing the babel runtime plugins with sleeper, ensuring that no extra downloads occur.

Now, loading either the podcast or video minis only result in about ~50kb each of data being downloaded. 

### How To Test

1. Load up the sleeper app, and load either the podcast or video minis from staging.
2. Observe log messages from `[BundleManager]`. Only two bundles should be downloaded: the main code file for the mini (`src_sleeper-podcasts_index_tsx.chunk.bundle`), and its module federation container (`sleeper-podcasts.container.bundle`);

### Screenshots/Video

Before

![Screen Shot 2023-08-07 at 2 00 00 PM](https://github.com/blitzstudios/sleeper-mini/assets/61988202/7fc5aedd-f706-4d20-b602-4c1082b72e43)

After

![Screen Shot 2023-08-07 at 1 50 41 PM](https://github.com/blitzstudios/sleeper-mini/assets/61988202/bae54150-b078-40f0-96d9-4812a966ae7e)
