### PR TITLE
Adding entitlements and header options system.

### DIFF
--- a/bin/build_mini.js
+++ b/bin/build_mini.js
@@ -32,7 +32,7 @@ const getCommands = (projectName) => {
   const zip = isWindows ?
     `powershell Compress-Archive -Path "${distPath}" -DestinationPath "${zipFilePath}"` :
     `cd dist && zip -r "${projectName}.zip" * && cd -`;
-  const openFile = isWindows ? `start .` : `open .`;
+  const openFile = isWindows ? `start dist` : `open dist`;
   const cleanIndex = `${removeDir} "${bundleOutputPath["ios"]}" "${bundleOutputPath["android"]}" "${sourcemapOutputPath["ios"]}" "${sourcemapOutputPath["android"]}"`;
   const cleanAll = `${removeDir} dist node_modules`;
   const cleanBuild = `${removeDir} "${distPath}" "${assetsDestPath["ios"]}" "${assetsDestPath["android"]}"`;
@@ -139,7 +139,7 @@ const validateProjectName = (name) => {
 const main = async () => {
   // Enter project name.
   const fallback = getProjectName();
-  const projectName = await getInput("Enter project name: ", fallback);
+  const projectName = await getInput("Enter project name (return to skip): ", fallback);
   if (!validateProjectName(projectName)) {
     printError("Invalid project name. Only alphanumeric characters and underscores are allowed.");
     process.exit(1);
@@ -167,6 +167,9 @@ const main = async () => {
   printInfo("Building Android...");
   await spawnProcess(commands.bundleAndroid, "webpack-bundle android command exited with non-zero code");
   printComplete("Android build complete.");
+
+  // Copy the app.json file to the dist folder
+  fs.copyFileSync('app.json', path.join('dist', projectName, 'app.json'));
 
   // Create Zip Archive
   printInfo("Creating zip archive...");

--- a/declarations/sleeper_entitlement.d.ts
+++ b/declarations/sleeper_entitlement.d.ts
@@ -1,0 +1,3 @@
+declare type SleeperEntitlement = 'user:email' | 'user:phone' | 'wallet:date_of_birth' | 'wallet:first_name' | 'wallet:last_name' | 'wallet:country_code' | 'wallet:city' | 'location:longitude' | 'location:latitude' | 'location:state' | 'location:country' | 'location:postalCode';
+
+export default SleeperEntitlement;

--- a/declarations/sleeper_header_options.d.ts
+++ b/declarations/sleeper_header_options.d.ts
@@ -1,0 +1,5 @@
+declare class SleeperHeaderOptions {
+    useLeagueSelector?: boolean;
+}
+
+export default SleeperHeaderOptions;

--- a/declarations/sleeper_message.d.ts
+++ b/declarations/sleeper_message.d.ts
@@ -1,7 +1,12 @@
+import type SleeperEntitlement from "@sleeperhq/mini-core/declarations/sleeper_entitlement";
+import type SleeperHeaderOptions from "@sleeperhq/mini-core/declarations/sleeper_header_options";
+
 type SocketMessage = {
     _ip?: string;
     _name?: string;
     _webpack?: string;
     _contextGet?: string;
+    _entitlements?: SleeperEntitlement[];
+    _headerOptions?: SleeperHeaderOptions;
 };
 export default SocketMessage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.4.10",
+  "version": "1.5.2",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.4.6",
+  "version": "1.4.10",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -98,11 +98,13 @@ const DevServer = props => {
 
         if (messageType.current === 'context') {
           // We should have a context object now
-          const context = new Proxy(json, handler);
-          props.onContextChanged(context);
+          const context = new Proxy(json._context, handler);
+          props.onContextChanged(context, json._entitlements);
         } else if (messageType.current === `partialContext`) {
           // We are updating a partial Context
-          props.onContextUpdated(json)
+          props.onContextUpdated(json._context);
+        } else if (messageType.current === 'entitlements') {
+          props.onEntitlementsUpdated(json._entitlements);
         }
 
         messageType.current = '';
@@ -196,10 +198,12 @@ const DevServer = props => {
       localAddress: ipAddress,
       reuseAddress: true,
     }, () => {
-      // When we establish a connection, send the IP address to the server
+      // When we establish a connection, send some data to the server
       const message: SocketMessage = { 
         _ip: ipAddress, 
-        _name: config.name, 
+        _name: config.name,
+        _entitlements: config.entitlements,
+        _headerOptions: config.headerOptions,
       };
       const json = JSON.stringify(message);
       console.log('[Sleeper] Send IP address: ', ipAddress, config.name);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
+import type SleeperEntitlement from '../../declarations/sleeper_entitlement.d';
+import type SleeperHeaderOptions from '../../declarations/sleeper_header_options.d';
+
 export * from '../../declarations/types/index.d';
-export { default as Context } from '../../declarations/sleeper_context.d';
+export type { default as Context } from '../../declarations/sleeper_context.d';
+export type { default as Entitlements } from '../../declarations/sleeper_entitlement.d';
+export type { default as HeaderOptions } from '../../declarations/sleeper_header_options.d';
 export type { default as SocketMessage } from '../../declarations/sleeper_message.d';
 
 export type Config = {
@@ -9,4 +14,6 @@ export type Config = {
   remoteSocketPort?: number,
   dev?: boolean,
   logsEnabled?: boolean,
+  entitlements?: SleeperEntitlement[],
+  headerOptions?: SleeperHeaderOptions,
 };

--- a/start.tsx
+++ b/start.tsx
@@ -18,21 +18,31 @@ DevServer.init(config);
 const Root = () => {
   const [context, setContext] = useState<Types.Context>({} as Types.Context);
   const [connected, setConnected] = useState<boolean>(false);
+  const [entitlements, setEntitlements] = useState<Types.Entitlements>({} as Types.Entitlements);
   const [, updateState] = React.useState<any>();
   const forceUpdate = React.useCallback(() => updateState({}), []);
 
-  const _onContextChanged = useCallback((data: Types.Context) => {
-    setContext(data);
+  const _onContextChanged = useCallback((context: Types.Context, entitlements: Types.Entitlements) => {
+    setContext(context);
+    setEntitlements(entitlements);
   }, []);
 
   const _onContextUpdated = useCallback(
-    (data: any) => {
+    (context: any) => {
       setContext(existing => {
-        for (const key in data) {
-          existing[key] = data[key];
+        for (const key in context) {
+          existing[key] = context[key];
         }
         return existing;
       });
+      forceUpdate();
+    },
+    [forceUpdate],
+  );
+
+  const _onEntitlementsUpdated = useCallback(
+    (entitlements: any) => {
+      setEntitlements(entitlements);
       forceUpdate();
     },
     [forceUpdate],
@@ -59,9 +69,10 @@ const Root = () => {
       <DevServer
         onContextChanged={_onContextChanged}
         onContextUpdated={_onContextUpdated}
+        onEntitlementsUpdated={_onEntitlementsUpdated}
         onConnected={_onConnected}
       />
-      {connected && <Project context={context} />}
+      {connected && <Project context={context} entitlements={entitlements} />}
       {!connected && _renderWaitingForConnection()}
     </SafeAreaView>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,15 +24,23 @@
   dependencies:
     "@babel/highlight" "^7.22.5"
 
+"@babel/code-frame@^7.22.10":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+  dependencies:
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
+
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.22.9":
+  version "7.22.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
+  integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.5":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.0.tgz#c241dc454e5b5917e40d37e525e2f4530c399298"
   integrity sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==
-
-"@babel/compat-data@^7.22.9":
-  version "7.22.9"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
-  integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
 
 "@babel/core@7.15.8":
   version "7.15.8"
@@ -106,6 +114,16 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.10.tgz#c92254361f398e160645ac58831069707382b722"
+  integrity sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==
+  dependencies:
+    "@babel/types" "^7.22.10"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
@@ -127,6 +145,17 @@
   dependencies:
     "@babel/helper-explode-assignable-expression" "^7.18.6"
     "@babel/types" "^7.18.9"
+
+"@babel/helper-compilation-targets@^7.13.0":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz#01d648bbc25dd88f513d862ee0df27b7d4e67024"
+  integrity sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==
+  dependencies:
+    "@babel/compat-data" "^7.22.9"
+    "@babel/helper-validator-option" "^7.22.5"
+    browserslist "^4.21.9"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
 
 "@babel/helper-compilation-targets@^7.15.4":
   version "7.22.9"
@@ -186,6 +215,20 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     regexpu-core "^5.3.1"
+
+"@babel/helper-define-polyfill-provider@^0.2.2", "@babel/helper-define-polyfill-provider@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz#8867aed79d3ea6cade40f801efb7ac5c66916b10"
+  integrity sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
 
 "@babel/helper-define-polyfill-provider@^0.3.3":
   version "0.3.3"
@@ -260,19 +303,19 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.14.5", "@babel/helper-module-imports@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   dependencies:
     "@babel/types" "^7.18.6"
-
-"@babel/helper-module-imports@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
-  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
-  dependencies:
-    "@babel/types" "^7.22.5"
 
 "@babel/helper-module-transforms@^7.15.8", "@babel/helper-module-transforms@^7.22.5":
   version "7.22.9"
@@ -318,7 +361,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
 
-"@babel/helper-plugin-utils@^7.22.5":
+"@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
   integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
@@ -475,6 +518,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.22.13":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.13.tgz#9cda839e5d3be9ca9e8c26b6dd69e7548f0cbf16"
+  integrity sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.5"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
@@ -493,6 +545,11 @@
   version "7.22.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
   integrity sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==
+
+"@babel/parser@^7.22.11":
+  version "7.22.14"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.14.tgz#c7de58e8de106e88efca42ce17f0033209dfd245"
+  integrity sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==
 
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.18.6"
@@ -879,6 +936,18 @@
     "@babel/helper-plugin-utils" "^7.20.2"
     regenerator-transform "^0.15.1"
 
+"@babel/plugin-transform-runtime@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz#d3aa650d11678ca76ce294071fda53d7804183b3"
+  integrity sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    babel-plugin-polyfill-corejs2 "^0.2.2"
+    babel-plugin-polyfill-corejs3 "^0.2.2"
+    babel-plugin-polyfill-regenerator "^0.2.2"
+    semver "^6.3.0"
+
 "@babel/plugin-transform-runtime@^7.0.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.21.0.tgz#2a884f29556d0a68cd3d152dcc9e6c71dfb6eee8"
@@ -1023,6 +1092,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.13.0":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.11.tgz#71ebb3af7a05ff97280b83f05f8865ac94b2027c"
+  integrity sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==
+  dependencies:
+    "@babel/code-frame" "^7.22.10"
+    "@babel/generator" "^7.22.10"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.22.11"
+    "@babel/types" "^7.22.11"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.22.5", "@babel/traverse@^7.22.6":
   version "7.22.8"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.8.tgz#4d4451d31bc34efeae01eac222b514a77aa4000e"
@@ -1057,6 +1142,15 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.22.10", "@babel/types@^7.22.11":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.11.tgz#0e65a6a1d4d9cbaa892b2213f6159485fe632ea2"
+  integrity sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    to-fast-properties "^2.0.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -1085,9 +1179,9 @@
     source-map "^0.7.3"
     ws "^8.7.0"
 
-"@callstack/repack@blitzstudios/repack.git#callstack-repack-v2.6.3-gitpkg":
-  version "2.6.3"
-  resolved "https://codeload.github.com/blitzstudios/repack/tar.gz/21a2629f69632dcb9cc3402eb4916940efa4755f"
+"@callstack/repack@blitzstudios/repack.git#callstack-repack-v2.7.0-gitpkg":
+  version "2.7.0"
+  resolved "https://codeload.github.com/blitzstudios/repack/tar.gz/d09bc0d220ee127e32583874c2fc686efb2ca2da"
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.7"
     colorette "^1.2.2"
@@ -2487,6 +2581,15 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-polyfill-corejs2@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz#6ed8e30981b062f8fe6aca8873a37ebcc8cc1c0f"
+  integrity sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==
+  dependencies:
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.2.4"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"
@@ -2496,6 +2599,14 @@ babel-plugin-polyfill-corejs2@^0.3.3:
     "@babel/helper-define-polyfill-provider" "^0.3.3"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs3@^0.2.2:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz#2779846a16a1652244ae268b1e906ada107faf92"
+  integrity sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.2.2"
+    core-js-compat "^3.16.2"
+
 babel-plugin-polyfill-corejs3@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz#56ad88237137eade485a71b52f72dbed57c6230a"
@@ -2503,6 +2614,13 @@ babel-plugin-polyfill-corejs3@^0.6.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.3"
     core-js-compat "^3.25.1"
+
+babel-plugin-polyfill-regenerator@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz#2e9808f5027c4336c994992b48a4262580cb8d6d"
+  integrity sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.2.4"
 
 babel-plugin-polyfill-regenerator@^0.4.1:
   version "0.4.1"
@@ -2654,7 +2772,7 @@ browserslist@^4.14.5, browserslist@^4.21.3, browserslist@^4.21.5:
     node-releases "^2.0.8"
     update-browserslist-db "^1.0.10"
 
-browserslist@^4.21.9:
+browserslist@^4.21.10, browserslist@^4.21.9:
   version "4.21.10"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.10.tgz#dbbac576628c13d3b2231332cb2ec5a46e015bb0"
   integrity sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==
@@ -3037,6 +3155,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==
+
+core-js-compat@^3.16.2:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.32.1.tgz#55f9a7d297c0761a8eb1d31b593e0f5b6ffae964"
+  integrity sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==
+  dependencies:
+    browserslist "^4.21.10"
 
 core-js-compat@^3.25.1:
   version "3.29.1"
@@ -6952,6 +7077,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@0.13.9:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4:
   version "0.13.11"


### PR DESCRIPTION
### Description

In order to facilitate third party minis requesting sensitive user data (like real name, email, phone, etc), this commit adds an "entitlement" system that grants the ability for minis to request this data from the user.

Note that this will require our approval before a mini is allowed to add these entitlements, and users will always be shown a prompt before sending that data over.

The commit also adds a way for minis to specify whether or not they want the league selector to appear for their mini. The configuration options can be expanded in the future.

If a mini wants to add an entitlement and header option, they will now do so in their app.json, like this:

{
  "name": "template",
  "displayName": "template",
  "remoteIP": "192.168.86.30",
  "samples": ["Mini", "FetchSample", "ActionSample", "Live/Video", "Live/Podcast"],
  "selectedSample": 0,
  "entitlements": ["user:email"],
  "headerOptions": {
    "useLeagueSelector": true
  }
} 

### How To Test

1. Edit the template project's `@sleeperhq/mini-core` package version to 1.4.7.
2. Adjust the template project's app.json to add one of the available entitlements.
3. Connect to Sleeper on the entitlements branch.
4. Open the developer mini. The first time you do this, a prompt should appear requesting permission.
5. You can also open the manage mini menu to re-request permissions at any time.
6. If permission is granted, the mini will now have access to this data in the entitlements property.
