### PR TITLE
Adding notification + player card actions.

### DIFF
--- a/declarations/navigation/index.d.ts
+++ b/declarations/navigation/index.d.ts
@@ -1,4 +1,4 @@
-import type { LeagueId, PlayerId, RosterId, TransactionId } from '..';
+import type { LeagueId, PlayerId, RosterId, SportType, TransactionId } from '..';
 export type NavigationParams = {
     LeaguesIndexScreen: undefined;
     LeaguesDetailScreen: LeaguesDetailScreenParams;
@@ -12,6 +12,7 @@ export type NavigationParams = {
     LeftDrawer: undefined;
     TradeCenterTransactionScreen: TradeCenterTransactionScreenParams;
     TradeCenterPlayersScreen: TradeCenterPlayersScreenParams;
+    PlayerPopupScreen: PlayerPopupScreenParams;
 };
 export type NavigationScreen = keyof NavigationParams;
 export type LeaguesDetailScreenParams = {
@@ -27,4 +28,8 @@ export type TradeCenterPlayersScreenParams = {
     rosterIds?: RosterId[];
     addMap?: Record<RosterId, PlayerId[]>;
     dropMap?: Record<RosterId, PlayerId[]>;
+};
+export type PlayerPopupScreenParams = {
+    playerId: PlayerId;
+    sport: SportType;
 };

--- a/declarations/sleeper_actions.d.ts
+++ b/declarations/sleeper_actions.d.ts
@@ -1,6 +1,8 @@
-import { NavigationParams, NavigationScreen, ToastConfig } from './types';
+import { NavigationParams, NavigationScreen, ToastConfig, Notification } from './types';
 export type SleeperActions = {
-    navigate: <T extends NavigationScreen>(screen: T, params?: NavigationParams[T]) => void;
-    requestLocation: () => void;
-    showToast: (toastData: ToastConfig) => void;
+    navigate?: <T extends NavigationScreen>(screen: T, params?: NavigationParams[T]) => void;
+    requestLocation?: () => void;
+    showToast?: (toastData: ToastConfig) => void;
+    scheduleNotification?: (notification: Notification) => Promise<string>;
+    cancelNotification?: (notificationId: string) => Promise<void>;
 };

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,6 +1,5 @@
 import { User, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap, Topic, Location } from './types';
 import type { SleeperActions } from './sleeper_actions';
-
 declare class SleeperContext {
     static apiLevel: string;
     user: User;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -59,14 +59,21 @@ export type DraftPickTradesInLeagueMap = Record<LeagueId, RosterDraftPick[]>;
 export type DraftPicksInDraftMap = Record<DraftId, DraftPick[]>;
 export type PlayersMap = Record<PlayerId, Player>;
 export type PlayersInSportMap = Record<SportType, PlayersMap>;
-export type Entitlement = 'user:email' | 'user:phone' | 'wallet:date_of_birth' | 'wallet:first_name' | 'wallet:last_name' | 'wallet:country_code' | 'wallet:city' | 'location:longitude' | 'location:latitude' | 'location:state' | 'location:country' | 'location:postalCode';
+export type Entitlement = 'user:email' | 'user:phone' | 'wallet:date_of_birth' | 'wallet:first_name' | 'wallet:last_name' | 'wallet:country_code' | 'wallet:city' | 'location:longitude' | 'location:latitude' | 'location:state' | 'location:country' | 'location:postalCode' | 'action:push_notification';
+export type Entitlements = Partial<Record<Entitlement, any>>;
 export declare const EntitlementDisplayText: Record<Entitlement, string>;
-export declare enum EventHandlerResult {
-    CONSUMED = "CONSUMED",
-    PROPAGATE = "PROPAGATE"
-}
+export type Notification = {
+    title?: string | undefined;
+    body?: string | undefined;
+    timestamp?: number;
+};
+export declare const EventHandlerResult: {
+    readonly CONSUMED: "CONSUMED";
+    readonly PROPAGATE: "PROPAGATE";
+};
+export type EventHandlerResultType = typeof EventHandlerResult[keyof typeof EventHandlerResult];
 export type Events = {
-    onBackButtonPressed?: () => EventHandlerResult;
+    onBackButtonPressed?: () => EventHandlerResultType;
 };
 export type HeaderOptions = {
     useLeagueSelector?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.5.5",
+  "version": "1.6.2",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ import type { HeaderOptions, Entitlement } from '../../declarations/types';
 export * from '../../declarations/types/index.d';
 export type { default as Context } from '../../declarations/sleeper_context.d';
 export type { default as SocketMessage } from '../../declarations/sleeper_message.d';
+export type { SleeperActions as Actions } from '../../declarations/sleeper_actions.d'
 
 export type Config = {
   name: string,


### PR DESCRIPTION
### Description

This commit adds new type definitions for the following calls:

```
const notificationId = actions.scheduleNotification({
  title?: string | undefined;
  body?: string | undefined;
  timestamp?: number;
})
```

```
actions.cancelNotification(notificationId)
```

```
actions.navigate('PlayerPopupScreen', {
  playerId: PlayerId,
  sport: SportType
}
```

It also splits out the `actions` object out from context into a new prop (but maintains the old context.actions for backwards compatibility)

```
type OwnProps = {
  context: Types.Context;
  events: Types.Events;
  actions: Types.Actions;
  entitlements: Types.Entitlements;
};

const TradeSample = (props: OwnProps) => {
  const {actions, context, events, entitlements} = props;

  ...
};
```

### How To Test

1. Connect to the notification API branch of the Sleeper app.
2. Test the above API calls.