### PR TITLE
Adding `sports` field to mini definition to allow minis to specify which sports they want data constrained to. Also updating to latest types.

### DIFF
--- a/bin/build_mini.js
+++ b/bin/build_mini.js
@@ -46,7 +46,7 @@ const getCommands = (projectName) => {
     --reset-cache \
     --bundle-output "${bundleOutputPath[platform]}" \
     --sourcemap-output "${sourcemapOutputPath[platform]}" \
-    --minify false \
+    --minify true \
     --assets-dest "${assetsDestPath[platform]}" \
     --webpackConfig ./node_modules/@sleeperhq/mini-core/webpack.config.js`;
   };

--- a/declarations/navigation/index.d.ts
+++ b/declarations/navigation/index.d.ts
@@ -1,4 +1,4 @@
-import type { LeagueId, PlayerId, RosterId, TransactionId } from '..';
+import type { LeagueId, PlayerId, RosterId, SportType, TransactionId } from '..';
 export type NavigationParams = {
     LeaguesIndexScreen: undefined;
     LeaguesDetailScreen: LeaguesDetailScreenParams;
@@ -12,6 +12,7 @@ export type NavigationParams = {
     LeftDrawer: undefined;
     TradeCenterTransactionScreen: TradeCenterTransactionScreenParams;
     TradeCenterPlayersScreen: TradeCenterPlayersScreenParams;
+    PlayerPopupScreen: PlayerPopupScreenParams;
 };
 export type NavigationScreen = keyof NavigationParams;
 export type LeaguesDetailScreenParams = {
@@ -27,4 +28,8 @@ export type TradeCenterPlayersScreenParams = {
     rosterIds?: RosterId[];
     addMap?: Record<RosterId, PlayerId[]>;
     dropMap?: Record<RosterId, PlayerId[]>;
+};
+export type PlayerPopupScreenParams = {
+    playerId: PlayerId;
+    sport: SportType;
 };

--- a/declarations/sleeper_actions.d.ts
+++ b/declarations/sleeper_actions.d.ts
@@ -1,6 +1,8 @@
-import { NavigationParams, NavigationScreen, ToastConfig } from './types';
+import { NavigationParams, NavigationScreen, ToastConfig, Notification } from './types';
 export type SleeperActions = {
-    navigate: <T extends NavigationScreen>(screen: T, params?: NavigationParams[T]) => void;
-    requestLocation: () => void;
-    showToast: (toastData: ToastConfig) => void;
+    navigate?: <T extends NavigationScreen>(screen: T, params?: NavigationParams[T]) => void;
+    requestLocation?: () => void;
+    showToast?: (toastData: ToastConfig) => void;
+    scheduleNotification?: (notification: Notification) => Promise<string>;
+    cancelNotification?: (notificationId: string) => Promise<void>;
 };

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,6 +1,5 @@
 import { User, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap, Topic, Location } from './types';
 import type { SleeperActions } from './sleeper_actions';
-
 declare class SleeperContext {
     static apiLevel: string;
     user: User;

--- a/declarations/sleeper_context.d.ts
+++ b/declarations/sleeper_context.d.ts
@@ -1,11 +1,13 @@
-import { User, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap, Topic, Location } from './types';
+import { User, League, LeaguesMap, RostersInLeagueMap, UserMap, MatchupsInLeagueMap, UsersInLeagueMap, PlayoffsInLeagueMap, TransactionsInLeagueMap, TransactionsMap, SportInfoMap, DraftsInLeagueMap, DraftPickTradesInLeagueMap, DraftPicksInDraftMap, PlayersInSportMap, Topic, Location, SportType } from './types';
 import type { SleeperActions } from './sleeper_actions';
 declare class SleeperContext {
     static apiLevel: string;
     user: User;
     league: League;
     leaguesMap: LeaguesMap;
+    leaguesMapBySport: Record<SportType, LeaguesMap>;
     userLeagueList: string[];
+    userLeagueListBySport: Record<SportType, string[]>;
     rostersInLeagueMap: RostersInLeagueMap;
     userMap: UserMap;
     matchupsInLeagueMap: MatchupsInLeagueMap;

--- a/declarations/sleeper_message.d.ts
+++ b/declarations/sleeper_message.d.ts
@@ -1,4 +1,4 @@
-import type { Entitlement, HeaderOptions } from './types';
+import type { Entitlement, HeaderOptions, SportType } from './types';
 type SocketMessage = {
     _ip?: string;
     _name?: string;
@@ -7,5 +7,6 @@ type SocketMessage = {
     _description?: string;
     _entitlements?: Entitlement[];
     _headerOptions?: HeaderOptions;
+    _sports?: SportType[];
 };
 export default SocketMessage;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -86,6 +86,7 @@ export type Mini = {
     email?: string;
     entitlements?: Entitlement[];
     headerOptions?: HeaderOptions;
+    sports?: SportType[];
 };
 export type Location = {
     state: string;

--- a/declarations/types/index.d.ts
+++ b/declarations/types/index.d.ts
@@ -59,14 +59,21 @@ export type DraftPickTradesInLeagueMap = Record<LeagueId, RosterDraftPick[]>;
 export type DraftPicksInDraftMap = Record<DraftId, DraftPick[]>;
 export type PlayersMap = Record<PlayerId, Player>;
 export type PlayersInSportMap = Record<SportType, PlayersMap>;
-export type Entitlement = 'user:email' | 'user:phone' | 'wallet:date_of_birth' | 'wallet:first_name' | 'wallet:last_name' | 'wallet:country_code' | 'wallet:city' | 'location:longitude' | 'location:latitude' | 'location:state' | 'location:country' | 'location:postalCode';
+export type Entitlement = 'user:email' | 'user:phone' | 'wallet:date_of_birth' | 'wallet:first_name' | 'wallet:last_name' | 'wallet:country_code' | 'wallet:city' | 'location:longitude' | 'location:latitude' | 'location:state' | 'location:country' | 'location:postalCode' | 'action:push_notification';
+export type Entitlements = Partial<Record<Entitlement, any>>;
 export declare const EntitlementDisplayText: Record<Entitlement, string>;
-export declare enum EventHandlerResult {
-    CONSUMED = "CONSUMED",
-    PROPAGATE = "PROPAGATE"
-}
+export type Notification = {
+    title?: string | undefined;
+    body?: string | undefined;
+    timestamp?: number;
+};
+export declare const EventHandlerResult: {
+    readonly CONSUMED: "CONSUMED";
+    readonly PROPAGATE: "PROPAGATE";
+};
+export type EventHandlerResultType = typeof EventHandlerResult[keyof typeof EventHandlerResult];
 export type Events = {
-    onBackButtonPressed?: () => EventHandlerResult;
+    onBackButtonPressed?: () => EventHandlerResultType;
 };
 export type HeaderOptions = {
     useLeagueSelector?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.6.3",
+  "version": "1.6.5",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",
@@ -43,7 +43,7 @@
     "@react-native-community/netinfo": "9.3.7",
     "axios": "0.15.3",
     "babel-loader": "9.1.2",
-    "react-native-fast-image": "https://github.com/blitzstudios/react-native-fast-image.git#release/1.1",
+    "react-native-fast-image": "https://github.com/blitzstudios/react-native-fast-image.git#release/1.2",
     "react-native-interactable": "https://github.com/blitzstudios/react-native-interactable",
     "react-native-linear-gradient": "2.5.6",
     "react-native-rename": "^3.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.5.5",
+  "version": "1.6.2",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -204,6 +204,7 @@ const DevServer = props => {
         _name: config.name,
         _entitlements: config.entitlements,
         _headerOptions: config.headerOptions,
+        _sports: config.sports,
       };
       const json = JSON.stringify(message);
       console.log('[Sleeper] Send IP address: ', ipAddress, config.name);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ import type { HeaderOptions, Entitlement } from '../../declarations/types';
 export * from '../../declarations/types/index.d';
 export type { default as Context } from '../../declarations/sleeper_context.d';
 export type { default as SocketMessage } from '../../declarations/sleeper_message.d';
+export type { SleeperActions as Actions } from '../../declarations/sleeper_actions.d'
 
 export type Config = {
   name: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { HeaderOptions, Entitlement } from '../../declarations/types';
+import type { HeaderOptions, Entitlement, SportType } from '../../declarations/types';
 
 export * from '../../declarations/types/index.d';
 export type { default as Context } from '../../declarations/sleeper_context.d';
@@ -14,4 +14,5 @@ export type Config = {
   logsEnabled?: boolean,
   entitlements?: Entitlement[],
   headerOptions?: HeaderOptions,
+  sports?: SportType[],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6948,9 +6948,9 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-"react-native-fast-image@https://github.com/blitzstudios/react-native-fast-image.git#release/1.1":
+"react-native-fast-image@https://github.com/blitzstudios/react-native-fast-image.git#release/1.2":
   version "8.5.11"
-  resolved "https://github.com/blitzstudios/react-native-fast-image.git#fad89d31e71c9b8cb198cb9a5ebabd1d42cdd660"
+  resolved "https://github.com/blitzstudios/react-native-fast-image.git#ad6c4b52bfb4f1ab2cfb316d373861acc0a9b724"
 
 "react-native-interactable@https://github.com/blitzstudios/react-native-interactable":
   version "0.1.10"


### PR DESCRIPTION
### Description

In order to ease the burden of filtering unwanted data for mini devs, this commit adds a new `sport` field in `app.json` that allows minis to automatically discard context data relating to other sports.

### How To Test

1. Connect to the `luke/fix/mini-league-filtering` branch in Sleeper.
2. Change the `sports` field in app.json.
3. Make sure context data is limited to only that sport.