### PR TITLE
Fix wrong packager IP

### DIFF
--- a/mini_packages.json
+++ b/mini_packages.json
@@ -17,7 +17,7 @@
     "@react-navigation/native": "6.1.3",
     "@react-navigation/stack": "6.3.12",
     "@shopify/flash-list": "1.4.1",
-    "@sleeperhq/mini-core": "1.8.5",
+    "@sleeperhq/mini-core": "1.8.6",
     "amazon-cognito-identity-js": "6.3.2",
     "crypto-js": "3.3.0",
     "decimal.js-light": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {Platform} from 'react-native';
+import {Platform, NativeModules} from 'react-native';
 import {Config, SocketMessage} from '../types';
-import { ScriptLocatorResolver, ScriptManager, Federated } from '@callstack/repack/client';
+import { ScriptLocatorResolver, ScriptManager } from '@callstack/repack/client';
 import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
 import TcpSocket from 'react-native-tcp-socket';
 import { fetchMainVersionMap, getMainUrl } from './url_resolver';
@@ -187,6 +187,10 @@ const DevServer = props => {
     // @ts-ignore
     const ipAddress = netInfoDetails?.ipAddress;
 
+    const scriptURL = NativeModules.SourceCode.scriptURL;
+    const address = scriptURL.split('://')[1].split('/')[0];
+    const packagerIP = address.split(':')[0];
+
     if (!netInfoDetails || !('ipAddress' in netInfoDetails)) {
       console.error('[Sleeper] Failed to determine local IP address.');
       return stopSocket();
@@ -200,7 +204,7 @@ const DevServer = props => {
     }, () => {
       // When we establish a connection, send some data to the server
       const message: SocketMessage = { 
-        _ip: ipAddress, 
+        _ip: packagerIP, 
         _name: config.name,
         _entitlements: config.entitlements,
         _headerOptions: config.headerOptions,


### PR DESCRIPTION
### Description
We're sending the mini's IP to fetch bundles, which works if the mini simulator and packager are the same machine. However if the mini is running on an external device, we need to send the packager IP to the app, so it knows where to fetch the bundles.

### How To Test

1. Test mini development on device instead of simulator