### PR TITLE
Fix for localhost packager default

### DIFF
--- a/mini_packages.json
+++ b/mini_packages.json
@@ -17,7 +17,7 @@
     "@react-navigation/native": "6.1.3",
     "@react-navigation/stack": "6.3.12",
     "@shopify/flash-list": "1.4.1",
-    "@sleeperhq/mini-core": "1.8.6",
+    "@sleeperhq/mini-core": "1.8.7",
     "amazon-cognito-identity-js": "6.3.2",
     "crypto-js": "3.3.0",
     "decimal.js-light": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -204,7 +204,7 @@ const DevServer = props => {
     }, () => {
       // When we establish a connection, send some data to the server
       const message: SocketMessage = { 
-        _ip: packagerIP, 
+        _ip: packagerIP === 'localhost' ? ipAddress : packagerIP, 
         _name: config.name,
         _entitlements: config.entitlements,
         _headerOptions: config.headerOptions,


### PR DESCRIPTION
Previously we used the mini IP if the packager and mini were on the same machine. We're reverting to this behavior if the packager is set to `localhost`.