### PR TITLE
Packager direct connect to Sleeper app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleeperhq/mini-core",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "description": "Core library frameworks for developing Sleeper Mini Apps.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/src/dev_server/index.tsx
+++ b/src/dev_server/index.tsx
@@ -202,26 +202,10 @@ const DevServer = props => {
       localAddress: ipAddress,
       reuseAddress: true,
     }, () => {
-      // When we establish a connection, send some data to the server
-      const message: SocketMessage = { 
-        _ip: packagerIP === 'localhost' ? ipAddress : packagerIP, 
-        _name: config.name,
-        _entitlements: config.entitlements,
-        _headerOptions: config.headerOptions,
-      };
-      const json = JSON.stringify(message);
-      console.log('[Sleeper] Send IP address: ', ipAddress, config.name);
-      try {
-        connection.current?.write(json + '\n', "utf8", (error) => {
-          if (error) {
-            return stopSocket();
-          }
-          console.log('[Sleeper] Connected to the Sleeper App.');
-          _onConnected(true);
-        });
-      } catch (e) {
-        return stopSocket();
-      }
+      console.log('[Sleeper] Connected to the Sleeper App.');
+      // When we establish a connection, request context
+      sendContextRequest(connection.current, "");
+      _onConnected(true);
     });
   
     connection.current.on('data', (data, ...args) => {

--- a/src/plugins/send_events.mjs
+++ b/src/plugins/send_events.mjs
@@ -1,0 +1,44 @@
+import { Socket } from 'net';
+import path from 'path';
+
+const appJsonFilename = 'app.json';
+const packagerConnectPort = 9092;
+
+const packagerConnect = async (rootPath) => {
+  const appJsonPath = path.join(rootPath, appJsonFilename);
+  // const appConfig = await import(appJsonPath);
+  const { default: appConfig } = await import(appJsonPath, { assert: { type: "json" } });
+
+  if (!appConfig.remoteIP) {
+    throw new Error(appJsonFilename + ' is missing remoteIP field');
+  }
+
+  const client = new Socket();
+  client.connect(packagerConnectPort, appConfig.remoteIP, () => {
+    console.log('Connected to Sleeper App at ', appConfig.remoteIP);
+
+    client.setEncoding('utf8');
+    const json = JSON.stringify({
+      _webpack: 'packager_connect',
+      _name: appConfig.name ?? 'please_set_name',
+      _entitlements: appConfig.entitlements,
+      _headerOptions: appConfig.headerOptions,
+    });
+
+    client.write(json, (err) => {
+      if (err) {
+        console.log('Error sending message to Sleeper App:', err);
+      }
+    });
+
+    client.on('error', () => {
+      client.destroy();
+    });
+  });
+
+  return () => {
+    client.destroy();
+  };
+};
+
+export default packagerConnect;

--- a/src/plugins/send_events.mjs
+++ b/src/plugins/send_events.mjs
@@ -20,7 +20,7 @@ const packagerConnect = async (rootPath) => {
     client.setEncoding('utf8');
     const json = JSON.stringify({
       _webpack: 'packager_connect',
-      _name: appConfig.name ?? 'please_set_name',
+      _name: appConfig.name ?? '',
       _entitlements: appConfig.entitlements,
       _headerOptions: appConfig.headerOptions,
     });


### PR DESCRIPTION
### Description
This removes the code that sends the mini packager ip to the Sleeper App from the Mini debug client. This code has been moved to an additional script that needs to be called by the packager. This will require a repack update to use.