### PR TITLE
Remove singleton for user packages as they'd conflict with other users

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = env => {
   const dev = mode === 'development';
 
   const sharedDeps = Object.keys(dependencies).reduce((acc, key) => {
-    acc[key] = {singleton: true, eager: dev, requiredVersion: dependencies[key]};
+    acc[key] = { eager: dev, requiredVersion: dependencies[key] };
     return acc;
   }, {});
 


### PR DESCRIPTION
We should be allowing different versions of packages to run in memory, thus removing singleton.